### PR TITLE
docs: fix expo install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This library needs some peer dependencies to work properly. You need to install 
 - for `expo` users:
 
 ```bash
-expo install react-native-reanimated @gorhom/portal
+npx expo install react-native-reanimated @gorhom/portal
 ```
 
 


### PR DESCRIPTION
## Why

Just a small addition to the installation command. Expo now, recommends [using versioned/local CLI for new projects](https://docs.expo.dev/workflow/expo-cli/). This means, to install a command `npx` is preferred over global `expo-cli`.

Thanks for adding instructions for the Expo users 💜 